### PR TITLE
Fix bug when camera has non-default viewport.

### DIFF
--- a/OutlineEffect/Assets/OutlineEffect/OutlineEffect.cs
+++ b/OutlineEffect/Assets/OutlineEffect/OutlineEffect.cs
@@ -131,6 +131,7 @@ public class OutlineEffect : MonoBehaviour
         _camera.backgroundColor = new Color(0.0f, 0.0f, 0.0f, 0.0f);
         _camera.clearFlags = CameraClearFlags.SolidColor;
         _camera.cullingMask = LayerMask.GetMask("Outline");
+        _camera.rect = new Rect (0, 0, 1, 1);
 
         if (outlineRenderers != null)
         {


### PR DESCRIPTION
If the main camera has viewport other then Rect(0,0,1,1) this is also copied onto _camera. This results in the outline being rendered in the wrong place. At least on Unity 5.3.2. Setting _camera.rect = new Rect(0,0,1,1) will render onto the entire camera, thus putting the outline in the right place.
