### PR TITLE
Make the enabling of all Outline instances optional

### DIFF
--- a/OutlineEffect/Assets/OutlineEffect/OutlineEffect.cs
+++ b/OutlineEffect/Assets/OutlineEffect/OutlineEffect.cs
@@ -76,6 +76,7 @@ namespace cakeslice
         public float alphaCutoff = .5f;
         public bool flipY = false;
         public Camera sourceCamera;
+        public bool autoEnableOutlines = true;
 
         [HideInInspector]
         public Camera outlineCamera;
@@ -242,12 +243,15 @@ namespace cakeslice
 
         private void OnEnable()
         {
-            Outline[] o = FindObjectsOfType<Outline>();
-
-            foreach(Outline oL in o)
+            if (autoEnableOutlines)
             {
-                oL.enabled = false;
-                oL.enabled = true;
+                Outline[] o = FindObjectsOfType<Outline>();
+
+                foreach (Outline oL in o)
+                {
+                    oL.enabled = false;
+                    oL.enabled = true;
+                }
             }
         }
 


### PR DESCRIPTION
This makes it possible to have disabled `Outline` components on your target objects in a scene at runtime and only enable them conditionally as needed. This allows you to turn outlines on and off without any allocations at runtime (as opposed to adding/destroying new `Outline` components at runtime when objects need to turn outlining on/off).

The default is `true`, so out-of-the-box, this PR doesn't change any behavior. You have to explicitly  toggle this new option in the inspector of the `OutlineEffect` component on your camera for this to change any behavior.
