### PR TITLE
Add outline to all child Renderers from where it's applied

### DIFF
--- a/OutlineEffect/Assets/OutlineEffect/Outline.cs
+++ b/OutlineEffect/Assets/OutlineEffect/Outline.cs
@@ -29,17 +29,16 @@ using System.Collections.Generic;
 namespace cakeslice
 {
     [ExecuteInEditMode]
-    [RequireComponent(typeof(Renderer))]
     public class Outline : MonoBehaviour
     {
-        public Renderer Renderer { get; private set; }
+        public Renderer[] Renderers { get; private set; }
 
         public int color;
         public bool eraseRenderer;
 
         private void Awake()
         {
-            Renderer = GetComponent<Renderer>();
+            Renderers = gameObject.GetComponentsInChildren<Renderer>();
         }
 
         void OnEnable()

--- a/OutlineEffect/Assets/OutlineEffect/OutlineEffect.cs
+++ b/OutlineEffect/Assets/OutlineEffect/OutlineEffect.cs
@@ -179,64 +179,41 @@ namespace cakeslice
 
                     if(outline != null && l == (l | (1 << outline.gameObject.layer)))
                     {
-                        for(int v = 0; v < outline.Renderer.sharedMaterials.Length; v++)
-                        {
-                            Material m = null;
+                        foreach(var Renderer in outline.Renderers) {
+                            for (int v = 0; v < Renderer.sharedMaterials.Length; v++) {
+                                Material m = null;
 
-                            if(outline.Renderer.sharedMaterials[v].mainTexture != null && outline.Renderer.sharedMaterials[v])
-                            {
-                                foreach(Material g in materialBuffer)
-                                {
-                                    if(g.mainTexture == outline.Renderer.sharedMaterials[v].mainTexture)
-                                    {
-                                        if(outline.eraseRenderer && g.color == outlineEraseMaterial.color)
-                                            m = g;
-                                        else if(g.color == GetMaterialFromID(outline.color).color)
-                                            m = g;
+                                if (Renderer.sharedMaterials[v].mainTexture != null && Renderer.sharedMaterials[v]) {
+                                    foreach (Material g in materialBuffer) {
+                                        if (g.mainTexture == Renderer.sharedMaterials[v].mainTexture) {
+                                            if (outline.eraseRenderer && g.color == outlineEraseMaterial.color)
+                                                m = g;
+                                            else if (g.color == GetMaterialFromID(outline.color).color)
+                                                m = g;
+                                        }
                                     }
-                                }
 
-                                if(m == null)
-                                {
-                                    if(outline.eraseRenderer)
-                                        m = new Material(outlineEraseMaterial);
+                                    if (m == null) {
+                                        if (outline.eraseRenderer)
+                                            m = new Material(outlineEraseMaterial);
+                                        else
+                                            m = new Material(GetMaterialFromID(outline.color));
+                                        m.mainTexture = Renderer.sharedMaterials[v].mainTexture;
+                                        materialBuffer.Add(m);
+                                    }
+                                } else {
+                                    if (outline.eraseRenderer)
+                                        m = outlineEraseMaterial;
                                     else
-                                        m = new Material(GetMaterialFromID(outline.color));
-                                    m.mainTexture = outline.Renderer.sharedMaterials[v].mainTexture;
-                                    materialBuffer.Add(m);
+                                        m = GetMaterialFromID(outline.color);
                                 }
-                            }
-                            else
-                            {
-                                if(outline.eraseRenderer)
-                                    m = outlineEraseMaterial;
+
+                                if (backfaceCulling)
+                                    m.SetInt("_Culling", (int)UnityEngine.Rendering.CullMode.Back);
                                 else
-                                    m = GetMaterialFromID(outline.color);
-                            }
+                                    m.SetInt("_Culling", (int)UnityEngine.Rendering.CullMode.Off);
 
-                            if(backfaceCulling)
-                                m.SetInt("_Culling", (int)UnityEngine.Rendering.CullMode.Back);
-                            else
-                                m.SetInt("_Culling", (int)UnityEngine.Rendering.CullMode.Off);
-
-                            commandBuffer.DrawRenderer(outline.GetComponent<Renderer>(), m, 0, 0);
-                            MeshFilter mL = outline.GetComponent<MeshFilter>();
-                            if(mL)
-                            {
-                                if(mL.sharedMesh != null)
-                                {
-                                    for(int i = 1; i < mL.sharedMesh.subMeshCount; i++)
-                                        commandBuffer.DrawRenderer(outline.GetComponent<Renderer>(), m, i, 0);
-                                }
-                            }
-                            SkinnedMeshRenderer sMR = outline.GetComponent<SkinnedMeshRenderer>();
-                            if(sMR)
-                            {
-                                if(sMR.sharedMesh != null)
-                                {
-                                    for(int i = 1; i < sMR.sharedMesh.subMeshCount; i++)
-                                        commandBuffer.DrawRenderer(outline.GetComponent<Renderer>(), m, i, 0);
-                                }
+                                commandBuffer.DrawRenderer(Renderer, m, 0, 0);
                             }
                         }
                     }


### PR DESCRIPTION
First of all - thanks for the great library.

Almost every time I've used this library I've found myself intuitively wanting to apply the Outline component to a parent object and have it apply automatically to all children. Usually I have one gameobject where I conceptually turn on/off the outline and expect everything within to be outlined, and going through turning it on/off for each renderer is a real hassle.

I would be interested to hear your opinion on that and have attached the code for how I prefer to use this effect. There are some issues with this PR, but I wanted to start the discussion about whether this was worthwhile or if I've missed something before I put the work into polishing this.

Outstanding issues with this PR:
* Breaks back compatibility - might want to default to the old behaviour and have this as an option
* Wasn't sure what was going on with the skinnedmeshrenderer etc, will need to fix that back up for this to be a viable PR