### PR TITLE
Fixes issue where multiple outline cameras may be created

### DIFF
--- a/OutlineEffect/Assets/OutlineEffect/OutlineEffect.cs
+++ b/OutlineEffect/Assets/OutlineEffect/OutlineEffect.cs
@@ -138,10 +138,21 @@ namespace cakeslice
 
             if(outlineCamera == null)
             {
-                GameObject cameraGameObject = new GameObject("Outline Camera");
-                cameraGameObject.transform.parent = sourceCamera.transform;
-                outlineCamera = cameraGameObject.AddComponent<Camera>();
-                outlineCamera.enabled = false;
+                foreach(Camera c in GetComponentsInChildren<Camera>()) {
+                    if (c.name == "Outline Camera") {
+                        outlineCamera = c;
+                        c.enabled = false;
+
+                        break;
+                    }
+                }
+
+                if(outlineCamera == null) {
+                    GameObject cameraGameObject = new GameObject("Outline Camera");
+                    cameraGameObject.transform.parent = sourceCamera.transform;
+                    outlineCamera = cameraGameObject.AddComponent<Camera>();
+                    outlineCamera.enabled = false;
+                }
             }
 
             renderTexture = new RenderTexture(sourceCamera.pixelWidth, sourceCamera.pixelHeight, 16, RenderTextureFormat.Default);


### PR DESCRIPTION
If the main camera is used in a prefab then new outline cameras may be created every time the scene is played. This fix checks to see if an outline camera has already been created and assigns it if it has. Otherwise it is created as normal