### PR TITLE
avoid error log when the target material doesn't have _MainTex property

### DIFF
--- a/OutlineEffect/Assets/OutlineEffect/OutlineEffect.cs
+++ b/OutlineEffect/Assets/OutlineEffect/OutlineEffect.cs
@@ -183,7 +183,9 @@ namespace cakeslice
                         {
                             Material m = null;
 
-                            if (outline.Renderer.sharedMaterials[v].mainTexture != null && outline.Renderer.sharedMaterials[v])
+                            if (outline.Renderer.sharedMaterials[v].HasProperty("_MainTex")
+                                && outline.Renderer.sharedMaterials[v].mainTexture != null
+                                && outline.Renderer.sharedMaterials[v])
                             {
                                 foreach (Material g in materialBuffer)
                                 {


### PR DESCRIPTION
I fixed error "Material doesn't have a texture property '_MainTex'" by cheking the properties of the target material.
This will fix https://github.com/cakeslice/Outline-Effect/issues/32 .

I think it is important issue, because when the material doesn't have _MainTex and if there's many meshes, OutlineEffect will output too many logs that it cause severe lag.
