### PR TITLE
Fix so disabled outlines is not included

### DIFF
--- a/OutlineEffect/OutlineEffect.cs
+++ b/OutlineEffect/OutlineEffect.cs
@@ -292,7 +292,7 @@ namespace cakeslice
 			{
 				foreach (Outline oL in o)
 				{
-					if (!outlines.Contains(oL))
+					if (oL.enabled && !outlines.Contains(oL))
 						outlines.Add(oL);
 				}
 			}


### PR DESCRIPTION
Disabled outlines shall never be added to the outlines list when
OutlineEffect is enabled.